### PR TITLE
Add support for the ExternalReferences field in components

### DIFF
--- a/component.go
+++ b/component.go
@@ -9,37 +9,44 @@ import (
 )
 
 type Component struct {
-	UUID               uuid.UUID `json:"uuid,omitempty"`
-	Author             string    `json:"author,omitempty"`
-	Publisher          string    `json:"publisher,omitempty"`
-	Group              string    `json:"group,omitempty"`
-	Name               string    `json:"name"`
-	Version            string    `json:"version"`
-	Classifier         string    `json:"classifier,omitempty"`
-	FileName           string    `json:"filename,omitempty"`
-	Extension          string    `json:"extension,omitempty"`
-	MD5                string    `json:"md5,omitempty"`
-	SHA1               string    `json:"sha1,omitempty"`
-	SHA256             string    `json:"sha256,omitempty"`
-	SHA384             string    `json:"sha384,omitempty"`
-	SHA512             string    `json:"sha512,omitempty"`
-	SHA3_256           string    `json:"sha3_256,omitempty"`
-	SHA3_384           string    `json:"sha3_384,omitempty"`
-	SHA3_512           string    `json:"sha3_512,omitempty"`
-	BLAKE2b_256        string    `json:"blake2b_256,omitempty"`
-	BLAKE2b_384        string    `json:"blake2b_384,omitempty"`
-	BLAKE2b_512        string    `json:"blake2b_512,omitempty"`
-	BLAKE3             string    `json:"blake3,omitempty"`
-	CPE                string    `json:"cpe,omitempty"`
-	PURL               string    `json:"purl,omitempty"`
-	SWIDTagID          string    `json:"swidTagId,omitempty"`
-	Internal           bool      `json:"isInternal,omitempty"`
-	Description        string    `json:"description,omitempty"`
-	Copyright          string    `json:"copyright,omitempty"`
-	License            string    `json:"license,omitempty"`
-	ResolvedLicense    *License  `json:"resolvedLicense,omitempty"`
-	DirectDependencies string    `json:"directDependencies,omitempty"`
-	Notes              string    `json:"notes,omitempty"`
+	UUID               uuid.UUID           `json:"uuid,omitempty"`
+	Author             string              `json:"author,omitempty"`
+	Publisher          string              `json:"publisher,omitempty"`
+	Group              string              `json:"group,omitempty"`
+	Name               string              `json:"name"`
+	Version            string              `json:"version"`
+	Classifier         string              `json:"classifier,omitempty"`
+	FileName           string              `json:"filename,omitempty"`
+	Extension          string              `json:"extension,omitempty"`
+	MD5                string              `json:"md5,omitempty"`
+	SHA1               string              `json:"sha1,omitempty"`
+	SHA256             string              `json:"sha256,omitempty"`
+	SHA384             string              `json:"sha384,omitempty"`
+	SHA512             string              `json:"sha512,omitempty"`
+	SHA3_256           string              `json:"sha3_256,omitempty"`
+	SHA3_384           string              `json:"sha3_384,omitempty"`
+	SHA3_512           string              `json:"sha3_512,omitempty"`
+	BLAKE2b_256        string              `json:"blake2b_256,omitempty"`
+	BLAKE2b_384        string              `json:"blake2b_384,omitempty"`
+	BLAKE2b_512        string              `json:"blake2b_512,omitempty"`
+	BLAKE3             string              `json:"blake3,omitempty"`
+	CPE                string              `json:"cpe,omitempty"`
+	PURL               string              `json:"purl,omitempty"`
+	SWIDTagID          string              `json:"swidTagId,omitempty"`
+	Internal           bool                `json:"isInternal,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	Copyright          string              `json:"copyright,omitempty"`
+	License            string              `json:"license,omitempty"`
+	ResolvedLicense    *License            `json:"resolvedLicense,omitempty"`
+	DirectDependencies string              `json:"directDependencies,omitempty"`
+	Notes              string              `json:"notes,omitempty"`
+	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
+}
+
+type ExternalReference struct {
+	Type    string `json:"type,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Comment string `json:"comment,omitempty"`
 }
 
 type ComponentService struct {


### PR DESCRIPTION
The API includes an `externalReferences` field in components, but this is currently ignored by the Go client. This PR adds the field to the type, so it will be captured when deserialised.

I suggest hiding whitespace when reviewing.

Untested, I have just checked that the names match up with the spec and what I see in the response when using the UI.