### PR TITLE
Update module name for internal fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DependencyTrack/client-go
+module github.com/monzo/dependency-track-client-go
 
 go 1.19
 


### PR DESCRIPTION
We want to use this fork until the upstream PR is merged - to do that it needs to identify itself correctly.